### PR TITLE
adding a `force: yes` to `user:` module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Deleted user removal
   user:
     name: "{{ item.username }}"
+    force: yes
     state: absent
   with_items: "{{ users_deleted }}"
   tags: ['users','configuration']


### PR DESCRIPTION
Observed logged in users were not deleted when module ran.
