### PR TITLE
adding home dir remove and active/inactive sessions remove

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,26 @@
 ---
+- name: Deleted active/inactive sessions for marked users 
+  command: "pkill -u {{ item.username }}"
+  with_items: "{{ users_deleted }}"
+  register: pkill_result
+  changed_when: "pkill_result.rc == 0"
+  failed_when: false
+  tags: ['users','configuration', 'users_delete']
+
 - name: Deleted user removal
   user:
     name: "{{ item.username }}"
     force: yes
     state: absent
   with_items: "{{ users_deleted }}"
-  tags: ['users','configuration']
+  tags: ['users','configuration', 'users_delete']
+
+- name: Delete home directory of marked users
+  file:
+    path: /home/{{ item.username }}
+    state: absent
+  with_items: "{{ users_deleted }}"
+  tags: ['users','configuration', 'users_delete']
 
 - name: Deleted per-user group removal
   group:


### PR DESCRIPTION
Adding below tasks and features:
1. removing all active/inactive sessions before a user removal. this will result a clean remove of a user.
2. adding a task to remove user's home directory after user remove task.
3. adding a `tag: users_delete` to enhance reusability of the role.